### PR TITLE
Update deprecated ehrQL methods

### DIFF
--- a/analysis/dataset_definition_comparator_large.py
+++ b/analysis/dataset_definition_comparator_large.py
@@ -20,30 +20,30 @@ age = (study_start_date - patients.date_of_birth).years
 
 # current registration
 registration = practice_registrations \
-    .drop(practice_registrations.start_date > (study_start_date - months(3))) \
-    .drop(practice_registrations.end_date <= study_start_date) \
+    .except_where(practice_registrations.start_date > (study_start_date - months(3))) \
+    .except_where(practice_registrations.end_date <= study_start_date) \
     .sort_by(practice_registrations.start_date).last_for_patient()
 
 # historical registration
 historical_registration = practice_registrations \
-    .drop(practice_registrations.start_date > date(2018, 11, 1)) \
-    .drop(practice_registrations.end_date < date(2019, 11, 1))
+    .except_where(practice_registrations.start_date > date(2018, 11, 1)) \
+    .except_where(practice_registrations.end_date < date(2019, 11, 1))
 
 # covid tests
 latest_test_before_diagnosis = sgss_covid_all_tests \
-    .take(sgss_covid_all_tests.is_positive) \
+    .where(sgss_covid_all_tests.is_positive) \
     .sort_by(sgss_covid_all_tests.specimen_taken_date).last_for_patient()
 
 # Potential end of follow-up before matching
 death_date = ons_deaths.sort_by(ons_deaths.date) \
     .last_for_patient().date
 end_reg_date = registration.end_date
-lc_dx_date = clinical_events.take(clinical_events.snomedct_code.is_in(lc_codelists_combined)) \
+lc_dx_date = clinical_events.where(clinical_events.snomedct_code.is_in(lc_codelists_combined)) \
     .sort_by(clinical_events.date) \
     .first_for_patient().date # LC dx dates
 
 dataset = Dataset()
-dataset.set_population((age >= 18) & registration.exists_for_patient())
+dataset.define_population((age >= 18) & registration.exists_for_patient())
 dataset.age = age
 dataset.sex = patients.sex
 dataset.region = registration.practice_stp

--- a/analysis/dataset_definition_lc_gp_list.py
+++ b/analysis/dataset_definition_lc_gp_list.py
@@ -7,15 +7,15 @@ from databuilder.tables.beta.tpp import (
 from codelists import lc_codelists_combined
 
 # Patients with long covid diagnoses
-lc_dx = clinical_events.take(clinical_events.snomedct_code.is_in(lc_codelists_combined)) \
+lc_dx = clinical_events.where(clinical_events.snomedct_code.is_in(lc_codelists_combined)) \
     .sort_by(clinical_events.date) \
     .first_for_patient()
 
 # current registration; do not exclude less than 1 year registration.
 registration = practice_registrations \
-    .drop(practice_registrations.end_date <= date(2020, 11, 1)) \
+    .except_where(practice_registrations.end_date <= date(2020, 11, 1)) \
     .sort_by(practice_registrations.start_date).last_for_patient()
 
 dataset = Dataset()
-dataset.set_population(lc_dx.exists_for_patient())
+dataset.define_population(lc_dx.exists_for_patient())
 dataset.gp_practice = registration.practice_pseudo_id

--- a/analysis/variables.py
+++ b/analysis/variables.py
@@ -22,7 +22,7 @@ study_start_date = date(2020, 11, 1)
 def add_visits(dataset, from_date, num_months):
     # Number of GP visits within `num_months` of `from_date`
     num_visits = appointments \
-        .take((appointments.start_date >= from_date) &
+        .where((appointments.start_date >= from_date) &
               (appointments.start_date <= (from_date + days(num_months * 30)))) \
         .count_for_patient()
     setattr(dataset, f"gp_visit_m{num_months}", num_visits)
@@ -31,7 +31,7 @@ def add_visits(dataset, from_date, num_months):
 # def add_ae_visits(dataset, from_date, num_months):
 #     # Number of A&E visits within `num_months` of `from_date`
 #     num_visits = emergency_care_attendances \
-#         .take((emergency_care_attendances.arrival_date >= from_date) &
+#         .where((emergency_care_attendances.arrival_date >= from_date) &
 #               (emergency_care_attendances.arrival_date  <= (from_date + days(num_months * 30)))) \
 #         .count_for_patient()
 #     setattr(dataset, f"gp_visit_m{num_months}", num_visits)
@@ -41,7 +41,7 @@ def add_visits(dataset, from_date, num_months):
 # def add_hos_visits(dataset, from_date, num_months):
 #     # Number of Hospitalisation within `num_months` of `from_date`
 #     num_visits = appointments \
-#         .take((hospital_admissions.admission_date >= from_date) &
+#         .where((hospital_admissions.admission_date >= from_date) &
 #               (hospital_admissions.discharge_date  <= (from_date + days(num_months * 30)))) \
 #         .count_for_patient()
 #     setattr(dataset, f"gp_visit_m{num_months}", num_visits)
@@ -75,12 +75,12 @@ def hospitalisation_diagnosis_matches(admissions, codelist):
     admissions.all_diagnoses.contains(code_string)
     for code_string in code_strings
   ]
-  return admissions.take(any_of(conditions))
+  return admissions.where(any_of(conditions))
 
 
 # Function for extracting clinical factors
 def clinical_ctv3_matches(gpevent, codelist):
-    gp_dx = (gpevent.take((gpevent.date < study_start_date) & gpevent.ctv3_code.is_in(codelist))
+    gp_dx = (gpevent.where((gpevent.date < study_start_date) & gpevent.ctv3_code.is_in(codelist))
       .sort_by(gpevent.date).last_for_patient()
     )
     return gp_dx


### PR DESCRIPTION
The following ehrQL methods have been updated:
- `.take` is now `.where` 
- `.drop` is now `.except_where` 
- `.set_population` is now `.define_population`