### PR TITLE
Update `ons_deaths` table

### DIFF
--- a/analysis/archieved codes/analyses_using_the_old_build_cost/covariates.py
+++ b/analysis/archieved codes/analyses_using_the_old_build_cost/covariates.py
@@ -66,8 +66,7 @@ lc_dx_date = lc_dx.date.if_null_then(study_end_date)
 
 # define end date: lc dx date +12 | death | derigistration | post COVID-19 syndrome resolved
 one_year_after_start = lc_dx.date + days(365) 
-death_date = ons_deaths.sort_by(ons_deaths.date) \
-    .last_for_patient().date.if_null_then(study_end_date)
+death_date = ons_deaths.date.if_null_then(study_end_date)
 end_reg_date = practice_registrations \
     .where(practice_registrations.start_date <= study_start_date - days(90))\
     .except_where(practice_registrations.end_date <= study_start_date) \

--- a/analysis/covariates.py
+++ b/analysis/covariates.py
@@ -66,8 +66,7 @@ lc_dx_date = lc_dx.date.if_null_then(study_end_date)
 
 # define end date: lc dx date +12 | death | derigistration | post COVID-19 syndrome resolved
 one_year_after_start = lc_dx.date + days(365) 
-death_date = ons_deaths.sort_by(ons_deaths.date) \
-    .last_for_patient().date.if_null_then(study_end_date)
+death_date = ons_deaths.date.if_null_then(study_end_date)
 end_reg_date = practice_registrations \
     .where(practice_registrations.start_date <= study_start_date - days(90))\
     .except_where(practice_registrations.end_date <= study_start_date) \


### PR DESCRIPTION
The `ons_deaths` table is now a PatientFrame (with one row per patient) so it is no longer needed to select one event per patient from the ons_deaths table.